### PR TITLE
fix: make fix compatible with node < v6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 "use strict";
+var initBuffer = require('./init-buffer');
 
 if (!Buffer.prototype.indexOf) {
     Buffer.prototype.indexOf = function (value, offset) {
@@ -7,9 +8,9 @@ if (!Buffer.prototype.indexOf) {
         // Always wrap the input as a Buffer so that this method will support any
         // data type such as array octet, string or buffer.
         if (typeof value === "string" || value instanceof String) {
-            value = Buffer.from(value);
+            value = initBuffer(value);
         } else if (typeof value === "number" || value instanceof Number) {
-            value = Buffer.from([ value ]);
+            value = initBuffer([ value ]);
         }
 
         var len = value.length;
@@ -37,9 +38,9 @@ function bufferLastIndexOf (value, offset) {
     // Always wrap the input as a Buffer so that this method will support any
     // data type such as array octet, string or buffer.
     if (typeof value === "string" || value instanceof String) {
-        value = Buffer.from(value);
+        value = initBuffer(value);
     } else if (typeof value === "number" || value instanceof Number) {
-        value = Buffer.from([ value ]);
+        value = initBuffer([ value ]);
     }
 
     var len = value.length;
@@ -65,7 +66,7 @@ function bufferLastIndexOf (value, offset) {
 
 if (Buffer.prototype.lastIndexOf) {
     // check Buffer#lastIndexOf is usable: https://github.com/nodejs/node/issues/4604
-    if (Buffer.from("ABC").lastIndexOf ("ABC") === -1)
+    if (initBuffer("ABC").lastIndexOf ("ABC") === -1)
         Buffer.prototype.lastIndexOf = bufferLastIndexOf;
 } else {
     Buffer.prototype.lastIndexOf = bufferLastIndexOf;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 "use strict";
-var initBuffer = require('./init-buffer');
+var initBuffer = require("./init-buffer");
 
 if (!Buffer.prototype.indexOf) {
     Buffer.prototype.indexOf = function (value, offset) {

--- a/init-buffer.js
+++ b/init-buffer.js
@@ -1,8 +1,8 @@
 module.exports = function initBuffer(val) {
   // assume old version
-  var nodeVersion = process && process.version ? process.version : 'v5.0.0';
-  var major = nodeVersion.split('.')[0].replace('v', '');
-  return major < 6
+    var nodeVersion = process && process.version ? process.version : "v5.0.0";
+    var major = nodeVersion.split(".")[0].replace("v", "");
+    return major < 6
       ? new Buffer(val)
       : Buffer.from(val);
-}
+};

--- a/init-buffer.js
+++ b/init-buffer.js
@@ -1,0 +1,8 @@
+module.exports = function initBuffer(val) {
+  // assume old version
+  var nodeVersion = process && process.version ? process.version : 'v5.0.0';
+  var major = nodeVersion.split('.')[0].replace('v', '');
+  return major < 6
+      ? new Buffer(val)
+      : Buffer.from(val);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "fix": "eslint . --fix"
   },
   "author": "https://github.com/sarosia",
   "license": "MIT",

--- a/test/indexof.js
+++ b/test/indexof.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var expect = require("chai").expect;
-var initBuffer = require('../init-buffer');
+var initBuffer = require("../init-buffer");
 
 require("../index.js");
 

--- a/test/indexof.js
+++ b/test/indexof.js
@@ -1,30 +1,34 @@
 "use strict";
 
 var expect = require("chai").expect;
+var initBuffer = require('../init-buffer');
+
 require("../index.js");
+
+console.log('NODE_VERSION', process.version);
 
 describe("Buffer#indexOf", function () {
 
     it("Buffer as value", function () {
-        var buffer = Buffer.from("ABC");
+        var buffer = initBuffer("ABC");
 
-        expect(buffer.indexOf(Buffer.from("ABC"))).to.be.equal(0);
-        expect(buffer.indexOf(Buffer.from("AB"))).to.be.equal(0);
-        expect(buffer.indexOf(Buffer.from("BC"))).to.be.equal(1);
-        expect(buffer.indexOf(Buffer.from("C"))).to.be.equal(2);
-        expect(buffer.indexOf(Buffer.from("CC"))).to.be.equal(-1);
-        expect(buffer.indexOf(Buffer.from("CA"))).to.be.equal(-1);
+        expect(buffer.indexOf(initBuffer("ABC"))).to.be.equal(0);
+        expect(buffer.indexOf(initBuffer("AB"))).to.be.equal(0);
+        expect(buffer.indexOf(initBuffer("BC"))).to.be.equal(1);
+        expect(buffer.indexOf(initBuffer("C"))).to.be.equal(2);
+        expect(buffer.indexOf(initBuffer("CC"))).to.be.equal(-1);
+        expect(buffer.indexOf(initBuffer("CA"))).to.be.equal(-1);
 
-        expect(buffer.indexOf(Buffer.from("ABC"), 1)).to.be.equal(-1);
-        expect(buffer.indexOf(Buffer.from("AB"), 1)).to.be.equal(-1);
-        expect(buffer.indexOf(Buffer.from("BC"), 1)).to.be.equal(1);
-        expect(buffer.indexOf(Buffer.from("C"), 1)).to.be.equal(2);
-        expect(buffer.indexOf(Buffer.from("CC"), 1)).to.be.equal(-1);
-        expect(buffer.indexOf(Buffer.from("CA"), 1)).to.be.equal(-1);
+        expect(buffer.indexOf(initBuffer("ABC"), 1)).to.be.equal(-1);
+        expect(buffer.indexOf(initBuffer("AB"), 1)).to.be.equal(-1);
+        expect(buffer.indexOf(initBuffer("BC"), 1)).to.be.equal(1);
+        expect(buffer.indexOf(initBuffer("C"), 1)).to.be.equal(2);
+        expect(buffer.indexOf(initBuffer("CC"), 1)).to.be.equal(-1);
+        expect(buffer.indexOf(initBuffer("CA"), 1)).to.be.equal(-1);
     });
 
     it("String as value", function () {
-        var buffer = Buffer.from("ABC");
+        var buffer = initBuffer("ABC");
 
         expect(buffer.indexOf("ABC")).to.be.equal(0);
         expect(buffer.indexOf("AB")).to.be.equal(0);
@@ -42,7 +46,7 @@ describe("Buffer#indexOf", function () {
     });
 
     it("Number as value", function () {
-        var buffer = Buffer.from([ 1, 2, 3 ]);
+        var buffer = initBuffer([ 1, 2, 3 ]);
 
         expect(buffer.indexOf(1)).to.be.equal(0);
         expect(buffer.indexOf(2)).to.be.equal(1);
@@ -59,25 +63,25 @@ describe("Buffer#indexOf", function () {
 describe("Buffer#lastIndexOf", function () {
 
     it("Buffer as value", function () {
-        var buffer = Buffer.from("ABCABC");
+        var buffer = initBuffer("ABCABC");
 
-        expect(buffer.lastIndexOf(Buffer.from("ABC"))).to.be.equal(3);
-        expect(buffer.lastIndexOf(Buffer.from("AB"))).to.be.equal(3);
-        expect(buffer.lastIndexOf(Buffer.from("BC"))).to.be.equal(4);
-        expect(buffer.lastIndexOf(Buffer.from("C"))).to.be.equal(5);
-        expect(buffer.lastIndexOf(Buffer.from("CC"))).to.be.equal(-1);
-        expect(buffer.lastIndexOf(Buffer.from("CA"))).to.be.equal(2);
+        expect(buffer.lastIndexOf(initBuffer("ABC"))).to.be.equal(3);
+        expect(buffer.lastIndexOf(initBuffer("AB"))).to.be.equal(3);
+        expect(buffer.lastIndexOf(initBuffer("BC"))).to.be.equal(4);
+        expect(buffer.lastIndexOf(initBuffer("C"))).to.be.equal(5);
+        expect(buffer.lastIndexOf(initBuffer("CC"))).to.be.equal(-1);
+        expect(buffer.lastIndexOf(initBuffer("CA"))).to.be.equal(2);
 
-        expect(buffer.lastIndexOf(Buffer.from("ABC"), 1)).to.be.equal(0);
-        expect(buffer.lastIndexOf(Buffer.from("AB"), 1)).to.be.equal(0);
-        expect(buffer.lastIndexOf(Buffer.from("BC"), 1)).to.be.equal(1);
-        expect(buffer.lastIndexOf(Buffer.from("C"), 1)).to.be.equal(-1);
-        expect(buffer.lastIndexOf(Buffer.from("CC"), 1)).to.be.equal(-1);
-        expect(buffer.lastIndexOf(Buffer.from("CA"), 1)).to.be.equal(-1);
+        expect(buffer.lastIndexOf(initBuffer("ABC"), 1)).to.be.equal(0);
+        expect(buffer.lastIndexOf(initBuffer("AB"), 1)).to.be.equal(0);
+        expect(buffer.lastIndexOf(initBuffer("BC"), 1)).to.be.equal(1);
+        expect(buffer.lastIndexOf(initBuffer("C"), 1)).to.be.equal(-1);
+        expect(buffer.lastIndexOf(initBuffer("CC"), 1)).to.be.equal(-1);
+        expect(buffer.lastIndexOf(initBuffer("CA"), 1)).to.be.equal(-1);
     });
 
     it("String as value", function () {
-        var buffer = Buffer.from("ABCABC");
+        var buffer = initBuffer("ABCABC");
 
         expect(buffer.lastIndexOf("ABC")).to.be.equal(3);
         expect(buffer.lastIndexOf("AB")).to.be.equal(3);
@@ -113,7 +117,7 @@ describe("Buffer#lastIndexOf", function () {
     });
 
     it("Number as value", function () {
-        var buffer = Buffer.from([ 1, 2, 3, 1, 2, 3]);
+        var buffer = initBuffer([ 1, 2, 3, 1, 2, 3]);
 
         expect(buffer.lastIndexOf(1)).to.be.equal(3);
         expect(buffer.lastIndexOf(2)).to.be.equal(4);


### PR DESCRIPTION
**Problem**
[My last PR](https://github.com/sarosia/buffer-indexof-polyfill/pull/3) broke for node versions < 6

**Solution**
Test better. This solution is has been tested on the following versions:
- iojs-v1.0.0
- iojs-v2.0.0
- iojs-v3.0.0
- v4.0.0
- v4.9.1 (lts/argon)
- v5.0.0
- v6.17.1 (lts/boron)
- v7.0.0
- v8.17.0 (lts/carbon)
- v9.0.0
- v10.0.0
- v11.0.0
- v12.16.3
- v12.18.3 (lts/erbium)

**Testing**
```
nvm install <version>
npm test
```